### PR TITLE
Export accesscontrol types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,12 @@ export * from './access-control.module';
 export * from './roles-builder.class';
 export * from './role.interface';
 export * from './access-control.guard';
-export { ROLES_BUILDER_TOKEN } from './constants'
+export type {
+  Access,
+  IAccessInfo,
+  Query,
+  IQueryInfo,
+  Permission,
+  AccessControlError,
+} from 'accesscontrol';
+export { ROLES_BUILDER_TOKEN } from './constants';


### PR DESCRIPTION
We want to be able to use interfaces such as [Permission](https://onury.io/accesscontrol/?api=ac#AccessControl~Permission) in our typedefs, so if we use `InjectRolesBuilder() ac: RolesBuilder` we can say `let perm: Permission = this.ac.can(roles).readAny('photos')`.

Alternatives:
Just use type inference: without the `: Permission`,  `perm` is still inferred as `Permission` type.  But what if we want to be explicit for readability?

Separately add `accesscontrol` to our `package.json` and import `Permission` separately.  This is fine (and what we'll do if this PR doesn't get accepted), but why not just give us these?

Is it because you rename `AccessControl`→`RoleBuilder`, and you don't want to add confusion by having both types available?

btw, for my specific PR, I would like to not export the classes themselves, but just the interfaces for type annotations. I would appreciate some guidance on doing without [global type exports](https://stackoverflow.com/questions/63588268/export-all-types-and-just-types-from-typescript-module)