### PR TITLE
feat(ac-guard): add support for GraphQL in ACGuard

### DIFF
--- a/lib/access-control.guard.js
+++ b/lib/access-control.guard.js
@@ -23,8 +23,16 @@ let ACGuard = class ACGuard {
         this.roleBuilder = roleBuilder;
     }
     async getUser(context) {
-        const request = context.switchToHttp().getRequest();
-        return request.user;
+        const contextType = context.getType().toString();
+        switch (contextType) {
+            case 'http':
+                return context.switchToHttp().getRequest().user;
+            case 'graphql':
+                const { GqlExecutionContext } = require('@nestjs/graphql');
+                return GqlExecutionContext.create(context).getContext().req.user;
+            default:
+                throw new Error(`Unsupported context type: ${contextType}`);
+        }
     }
     async getUserRoles(context) {
         const user = await this.getUser(context);


### PR DESCRIPTION
Currently, ACGuard support only `http` context. 

I add `GraphQL` context support in `ACGuard` inspired by userFactory function in UserRoles decorator.