### PR TITLE
chore: lock npmrc to work with yarnpkg

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.yarnpkg.com


### PR DESCRIPTION
This pull request lock the npm installation to work with yarnpkg in this repository